### PR TITLE
Bind ^H to erase too

### DIFF
--- a/config/binding/default
+++ b/config/binding/default
@@ -9,6 +9,7 @@ bind pgdown pgdown
 bind delete delete
 bind ^\[ unselect
 bind ^\? erase
+bind ^H erase
 
 bind C-left 'word-bwd -s'
 bind C-right 'word-fwd -s'


### PR DESCRIPTION
Depending on the terminal type, "erase" could be either `^?` or `^H` on FreeBSD (and probably other *BSD too).