### PR TITLE
Added Slackware to installing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ Installing
 
 `dte` can be installed via package manager on the following platforms:
 
-| OS                 | Install command                            |
-|--------------------|--------------------------------------------|
-| [Debian Testing]   | `apt-get install dte`                      |
-| Arch Linux ([AUR]) | `$AUR_HELPER -S dte`                       |
-| [Void Linux]       | `xbps-install -S dte`                      |
-| [FreeBSD]          | `pkg install dte`                          |
-| [OpenBSD]          | `pkg_add dte`                              |
-| NetBSD ([pkgsrc])  | `pkg_add dte`                              |
-| OS X ([Homebrew])  | `brew tap yumitsu/dte && brew install dte` |
-| Android ([Termux]) | `pkg install dte`                          |
+| OS                        | Install command                            |
+|---------------------------|--------------------------------------------|
+| [Debian Testing]          | `apt-get install dte`                      |
+| Arch Linux ([AUR])        | `$AUR_HELPER -S dte`                       |
+| [Void Linux]              | `xbps-install -S dte`                      |
+| Slackware ([Slackbuilds]) | [SlackBuild Usage HOWTO]                   | 
+| [FreeBSD]                 | `pkg install dte`                          |
+| [OpenBSD]                 | `pkg_add dte`                              |
+| NetBSD ([pkgsrc])         | `pkg_add dte`                              |
+| OS X ([Homebrew])         | `brew tap yumitsu/dte && brew install dte` |
+| Android ([Termux])        | `pkg install dte`                          |
 
 Building
 --------
@@ -104,6 +105,8 @@ Public License version 2 for more details.
 [Debian Testing]: https://packages.debian.org/testing/dte
 [AUR]: https://aur.archlinux.org/packages/dte/
 [Void Linux]: https://github.com/void-linux/void-packages/tree/master/srcpkgs/dte
+[Slackbuilds]: https://slackbuilds.org/repository/14.2/development/dte/
+[SlackBuild Usage HOWTO]: https://slackbuilds.org/howto/
 [FreeBSD]: https://svnweb.freebsd.org/ports/head/editors/dte/
 [OpenBSD]: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/editors/dte/
 [pkgsrc]: https://pkgsrc.se/editors/dte


### PR DESCRIPTION
I'm maintaining the dte Slackbuild since August 2018.

Today I submitted the new Slackbuld for dte version 1.9.1
This pull request is to update the dte installing section with the Slackbuild information.

Please check it out the best way to the "slackbuild" command, i.e. `./dte.SlackBuild`
That command is just giving the idea, because building and installing slackbuild is a sequence of manual commands:
- wget slackbuild archive
- untar slackbuild archive
- wget source code
- ./slackbuild
- installpkg /tmp/dte-1.9.1-x86_64-1_SBo.tgz

NOTE: The slackbuild maintainers will commit my submit (version 1.9.1) probably next week: ATM the dte version available in the slackbuild database is still the old 1.8.2 
